### PR TITLE
Fix js header content type

### DIFF
--- a/js/upbuttons.js.php
+++ b/js/upbuttons.js.php
@@ -1,5 +1,7 @@
 <?php
 
+	header('Content-Type: application/javascript');
+	
 	require '../config.php';
 
 	if(empty($user->rights->upbuttons->useit)) exit;


### PR DESCRIPTION
Prevent js execution errors like : 
Refused to execute script from 'http://www.[...]/custom/upbuttons/js/upbuttons.js.php' [^] because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.




